### PR TITLE
9108-V1.7bf -> 9108.V1.7bf-sim

### DIFF
--- a/TeamCode/build.gradle
+++ b/TeamCode/build.gradle
@@ -13,3 +13,7 @@
 
 // Include common definitions from above.
 apply from: '../build.common.gradle'
+
+dependencies {
+    compile 'org.openftc:rev-extensions-2:1.2'
+}

--- a/TeamCode/build.gradle
+++ b/TeamCode/build.gradle
@@ -15,5 +15,5 @@
 apply from: '../build.common.gradle'
 
 dependencies {
-    compile 'org.openftc:rev-extensions-2:1.2'
+    implementation 'org.openftc:rev-extensions-2:1.2'
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/auto_classes/teleOpMecanum.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/auto_classes/teleOpMecanum.java
@@ -36,13 +36,13 @@ public class teleOpMecanum extends OpMode {
         double drivey = gamepad1.left_stick_y;
         double drivex = gamepad1.left_stick_x;
         double turn = -gamepad1.right_stick_x;
-        if (Math.abs(drivey) < .05) {
+        if (Math.abs((double)drivey) < .05) {
             drivey = 0;
         }
-        if (Math.abs(drivex) < .05) {
+        if (Math.abs((double)drivex) < .05) {
             drivex = 0;
         }
-        if (Math.abs(turn) < .05) {
+        if (Math.abs((double)turn) < .05) {
             turn = 0;
         }
         Position2DAngle relativeValues;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/auto_classes/teleOpMecanum.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/auto_classes/teleOpMecanum.java
@@ -33,10 +33,20 @@ public class teleOpMecanum extends OpMode {
     //Initialized by: After Start, Before Stop / loops
     @Override
     public void loop() {
-        double drivex = -gamepad1.left_stick_y;
-        double drivey = gamepad1.left_stick_x;
-        double turn  =  gamepad1.right_stick_x;
-        Position2DAngle relativeValues = Robot.DCG.relativeValues(new Position2DAngle(drivex,drivey,turn), Robot.IMU);
+        double drivey = gamepad1.left_stick_y;
+        double drivex = gamepad1.left_stick_x;
+        double turn = -gamepad1.right_stick_x;
+        if (Math.abs(drivey) < .05) {
+            drivey = 0;
+        }
+        if (Math.abs(drivex) < .05) {
+            drivex = 0;
+        }
+        if (Math.abs(turn) < .05) {
+            turn = 0;
+        }
+        Position2DAngle relativeValues;
+        relativeValues = Robot.DCG.relativeValues(new Position2DAngle(drivex,drivey,turn), Robot.IMU);
         Robot.DCG.driveToPositionAngle(relativeValues, true);
         telemetry.addData("Status", "Run Time: " + runtime.toString());
         telemetry.update();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/general_classes/Position2DAngle.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/general_classes/Position2DAngle.java
@@ -2,7 +2,6 @@ package org.firstinspires.ftc.teamcode.general_classes;
 
 // Representative of a Pos2D and an angle
 public class Position2DAngle {
-
     public double X;
     public double Y;
     public double ANGLE;
@@ -16,13 +15,5 @@ public class Position2DAngle {
     public double getMagnitude() {
         double magnitude = Math.hypot(X,Y);
         return magnitude;
-    }
-    public double getXLength() {
-        double X_r = X * Math.cos(ANGLE);
-        return X_r;
-    }
-    public double getYLength() {
-        double Y_r = Y * Math.sin(ANGLE);
-        return Y_r;
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team_classes/BNOIMU.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team_classes/BNOIMU.java
@@ -28,14 +28,14 @@ public class BNOIMU {
     }
 
     public void initialize(HardwareMap Hmap, Telemetry Tm) {
+        this.imu = Hmap.get(BNO055IMU.class, "imu");
         BNO055IMU.Parameters parameters = new BNO055IMU.Parameters();
-        parameters.mode                = BNO055IMU.SensorMode.IMU;
-        parameters.angleUnit           = BNO055IMU.AngleUnit.DEGREES;
-        parameters.accelUnit           = BNO055IMU.AccelUnit.METERS_PERSEC_PERSEC;
-        parameters.loggingEnabled      = false;
-        imu = Hmap.get(BNO055IMU .class,"imu");
-        imu.initialize(parameters);
-        imu.startAccelerationIntegration(new Position(), new Velocity(), 1000);
+        parameters.mode = BNO055IMU.SensorMode.IMU;
+        parameters.angleUnit = BNO055IMU.AngleUnit.DEGREES;
+        parameters.accelUnit = BNO055IMU.AccelUnit.METERS_PERSEC_PERSEC;
+        parameters.loggingEnabled = false;
+        this.imu.initialize(parameters);
+        this.imu.startAccelerationIntegration(new Position(), new Velocity(), 1000);
     }
 
     public double getAngle()

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team_classes/DcMotorGroup.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team_classes/DcMotorGroup.java
@@ -73,9 +73,9 @@ public class DcMotorGroup {
         double V3 = relativeY - relativeX - degreesAngle /* *(XYcombinedD)*/;
         double V4 = relativeY + relativeX + degreesAngle /* *(XYcombinedD)*/;
 
-        double largest = Math.max(Math.max(V1,V2),Math.max(V3,V4));
-        double smallest = Math.min(Math.min(V1,V2),Math.min(V3,V4));
-        double divisor = Math.max(Math.abs(largest), Math.abs(smallest));
+        double largest = Math.max((double)Math.max((double)V1,(double)V2),(double)Math.max((double)V3,(double)V4));
+        double smallest = Math.min((double)Math.min((double)V1,(double)V2),(double)Math.min((double)V3,(double)V4));
+        double divisor = Math.max((double)Math.abs((double)largest), (double)Math.abs((double)smallest));
 
         if (V1!=0) {
             V1 = (V1/divisor);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team_classes/DcMotorGroup.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team_classes/DcMotorGroup.java
@@ -39,9 +39,9 @@ public class DcMotorGroup {
         this.DcMotors[1] = Hmap.get(DcMotor.class, "left_drive_front");
         this.DcMotors[2] = Hmap.get(DcMotor.class, "left_drive_back");
         this.DcMotors[3] = Hmap.get(DcMotor.class, "right_drive_back");
-        this.DcMotors[0].setDirection(DcMotor.Direction.FORWARD);
+        this.DcMotors[0].setDirection(DcMotor.Direction.REVERSE);
         this.DcMotors[1].setDirection(DcMotor.Direction.FORWARD);
-        this.DcMotors[2].setDirection(DcMotor.Direction.REVERSE);
+        this.DcMotors[2].setDirection(DcMotor.Direction.FORWARD);
         this.DcMotors[3].setDirection(DcMotor.Direction.REVERSE);
         Tm.addData("Encoders","Resetting");
         this.DcMotors[0].setMode(DcMotor.RunMode.STOP_AND_RESET_ENCODER);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team_classes/DcMotorGroup.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team_classes/DcMotorGroup.java
@@ -62,7 +62,7 @@ public class DcMotorGroup {
     private final double Ydistance = 10.02;
     private double XYcombinedD = Xdistance + Ydistance;
     public void driveToPositionAngle(Position2DAngle PositionAngle, boolean teleOp) {
-        
+
         double relativeY = PositionAngle.X;
         double relativeX = PositionAngle.Y;
         double degreesAngle = PositionAngle.ANGLE;
@@ -129,22 +129,28 @@ public class DcMotorGroup {
     //FUNCTION 2: lots of trig going on, so have fun trying to figure it out
     public Position2DAngle relativeValues(Position2DAngle PosAngle, BNOIMU IMU) {
         double THETA_triangle;
-        if (PosAngle.X==0) {
-            /* The inclusion of 0 as part of the relative operator was deemed unnecessary
-             Since the final calculation would suss that out*/
-            if (PosAngle.Y > 1) {
+        if (PosAngle.X==0 && PosAngle.Y!=0) {
+            if (PosAngle.Y > 0) {
                 THETA_triangle = 90;
             } else {
                 THETA_triangle = -90;
             }
+        } else if (PosAngle.X!=0 && PosAngle.Y==0) {
+            if (PosAngle.X > 0) {
+                THETA_triangle = 0;
+            } else {
+                THETA_triangle = 180;
+            }
+        } else if (PosAngle.X==0 && PosAngle.Y==0) {
+            THETA_triangle = 0;
         } else {
-            THETA_triangle = Math.atan(PosAngle.Y/PosAngle.X);
+            THETA_triangle = Math.toDegrees(Math.atan2(PosAngle.Y,PosAngle.X));
         }
-        double THETA_relative = (-IMU.getAngle()) + THETA_triangle + PosAngle.ANGLE;
+        double THETA_relative = (THETA_triangle - IMU.getAngle());
         double L_hypotnuse = PosAngle.getMagnitude();
-        double X_New = L_hypotnuse * Math.cos(THETA_relative);
-        double Y_New = L_hypotnuse * Math.sin(THETA_relative);
-        return new Position2DAngle(X_New,Y_New,THETA_relative);
+        double X_New = L_hypotnuse * Math.cos(Math.toRadians(THETA_relative));
+        double Y_New = L_hypotnuse * Math.sin(Math.toRadians(THETA_relative));
+        return new Position2DAngle(X_New,Y_New,PosAngle.ANGLE);
     }
 
     //FUNCTION 3:

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team_classes/DcMotorGroup.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team_classes/DcMotorGroup.java
@@ -56,41 +56,44 @@ public class DcMotorGroup {
         Tm.update();
     }
 
+    //X = a, Y = b
+    //The distances are in inches
+    private final double Xdistance = 9.27;
+    private final double Ydistance = 10.02;
+    private double XYcombinedD = Xdistance + Ydistance;
     public void driveToPositionAngle(Position2DAngle PositionAngle, boolean teleOp) {
-
-        //X = a, Y = b
-        //The distances are in inches
-        final double Xdistance = 9.27;
-        final double Ydistance = 10.02;
-        double XYcombinedD = Xdistance + Ydistance;
-
+        
         double relativeY = PositionAngle.X;
         double relativeX = PositionAngle.Y;
         double degreesAngle = PositionAngle.ANGLE;
 
         //NOTE: This uses displacement instead of velocity, since in practice the ratio of velocity_X to velocity_Y, will be equal to ratio of displacement_X to displacement_Y.
-        double V1 = relativeY - relativeX + degreesAngle*(XYcombinedD);
-        double V2 = relativeY + relativeX - degreesAngle*(XYcombinedD);
-        double V3 = relativeY - relativeX - degreesAngle*(XYcombinedD);
-        double V4 = relativeY + relativeX + degreesAngle*(XYcombinedD);
+        double V1 = relativeY - relativeX + degreesAngle /* *(XYcombinedD)*/;
+        double V2 = relativeY + relativeX - degreesAngle /* *(XYcombinedD)*/;
+        double V3 = relativeY - relativeX - degreesAngle /* *(XYcombinedD)*/;
+        double V4 = relativeY + relativeX + degreesAngle /* *(XYcombinedD)*/;
 
         double largest = Math.max(Math.max(V1,V2),Math.max(V3,V4));
         double smallest = Math.min(Math.min(V1,V2),Math.min(V3,V4));
         double divisor = Math.max(Math.abs(largest), Math.abs(smallest));
 
-        V1 = 100*(V1/divisor);
-        V2 = 100*(V2/divisor);
-        V3 = 100*(V3/divisor);
-        V4 = 100*(V4/divisor);
+        if (V1!=0) {
+            V1 = (V1/divisor);
+            V2 = (V2/divisor);
+            V3 = (V3/divisor);
+            V4 = (V4/divisor);
+        }
 
+        this.setPower(new double[]{V1,V2,V3,V4});
+        /*
         double EncoderMax1 = inchToEncoder(0);
 
         if (teleOp == false) {
             //WHILE ENCODER LOOP HERE
         } else if (teleOp == true) {
-            this.setPower(new double[]{V1,V2,V3,V4});
-        }
 
+        }
+         */
     }
 
     //IF undeclared teleop, assumes auto drive method

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team_classes/DcMotorGroup.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team_classes/DcMotorGroup.java
@@ -63,8 +63,8 @@ public class DcMotorGroup {
     private double XYcombinedD = Xdistance + Ydistance;
     public void driveToPositionAngle(Position2DAngle PositionAngle, boolean teleOp) {
 
-        double relativeY = PositionAngle.X;
-        double relativeX = PositionAngle.Y;
+        double relativeY = PositionAngle.Y;
+        double relativeX = PositionAngle.X;
         double degreesAngle = PositionAngle.ANGLE;
 
         //NOTE: This uses displacement instead of velocity, since in practice the ratio of velocity_X to velocity_Y, will be equal to ratio of displacement_X to displacement_Y.

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team_classes/Robot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team_classes/Robot.java
@@ -1,5 +1,6 @@
 package org.firstinspires.ftc.teamcode.team_classes;
 
+import com.qualcomm.robotcore.hardware.DcMotor;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 
 import org.firstinspires.ftc.robotcore.external.Telemetry;
@@ -8,6 +9,13 @@ public class Robot {
     public DcMotorGroup DCG;
     public ColorSensorGroup CSG;
     public BNOIMU IMU;
+
+    //constructor
+    public Robot() {
+        DCG = new DcMotorGroup(new DcMotor[]{null,null,null,null});
+        CSG = new ColorSensorGroup(null);
+        IMU = new BNOIMU(null);
+    }
 
     public void initialize(HardwareMap HM, Telemetry T) {
         DCG.initialize(HM, T);


### PR DESCRIPTION
9108.V1.7bf-sim (17 November 2019)

**Fixed Issues:**
- Resolves #44 4350174
- Resolves #50 a16c388
- Resolves #51 01aa3c5
- Resolves #48 8a37d01
- Resolves #49 && Resolves #47 9ed970c
- Resolves #45 0f42d44
- Resolves #46 05f33e3
  - Basically the methodology behind enforcing the double parameter use in Math.methods was to redundantly cast an expression on the double variables. This way it cannot use it has an integer parameter. The IDE will bother you for having this redundant expression, but hopefully I won't waste three hours of my life again.